### PR TITLE
use --transform rather than --xform

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -109,7 +109,7 @@ if [ ! -d "$srcdir" ]; then
         fi
     fi
     #extract
-    tar xjvf "$srcfile" --show-transformed-names --xform 's#^[^/]*#php-'"$VERSION"'#'
+    tar xjvf "$srcfile" --show-transformed-names --transform 's#^[^/]*#php-'"$VERSION"'#'
 fi
 
 #do we need the Suhosin patch?


### PR DESCRIPTION
`--xform` makes compile.sh fail on systems with older versions of `tar`.

Pleas use `--transform` instead.

(the two are alias of each other, with xform being introduced recently and thus not being available on older systems)
