### PR TITLE
add new url to download php-7.1

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -81,6 +81,7 @@ sources=(
     "https://downloads.php.net/~stas/php-$SHORT_VERSION.tar.bz2"
     "https://downloads.php.net/~tyrael/php-$SHORT_VERSION.tar.bz2"
     "https://downloads.php.net/~ab/php-$SHORT_VERSION.tar.bz2"
+    "https://downloads.php.net/~krakjoe/php-$SHORT_VERSION.tar.bz2"
 )
 
 #already extracted?


### PR DESCRIPTION
php-7.1.0alpha1 released on different download path: https://downloads.php.net/~krakjoe/
I add this url to list.