### PR TITLE
Fix fallback urls

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -62,7 +62,7 @@ if [ ! -d "$srcdir" ]; then
             echo "Fetching sources from museum failed"
             echo $url
             #museum failed, now we try real download
-            url="https://www.php.net/get/php-$SHORT_VERSION.tar.bz2/from/this/mirror"
+            url="https://php.net/get/php-$SHORT_VERSION.tar.bz2/from/this/mirror"
             wget -P "$bzipsdir" -O "$srcfile" "$url"
         fi
         if [ ! -s "$srcfile" -a -f "$srcfile" ]; then
@@ -72,8 +72,7 @@ if [ ! -d "$srcdir" ]; then
         if [ ! -f "$srcfile" ]; then
             echo "Fetching sources from official download site failed"
             echo $url
-            #use ilia's RC (5.3.x)
-            url="https://downloads.php.net/ilia/php-$SHORT_VERSION.tar.bz2"
+            url="https://secure.php.net/distributions/php-$SHORT_VERSION.tar.bz2"
             wget -P "$bzipsdir" -O "$srcfile" "$url"
         fi
         if [ ! -s "$srcfile" -a -f "$srcfile" ]; then
@@ -81,32 +80,9 @@ if [ ! -d "$srcdir" ]; then
         fi
 
         if [ ! -f "$srcfile" ]; then
-            echo "Fetching sources from ilia's site failed"
+            echo "Fetching sources from secure.php.net failed"
             echo $url
-            #use stas's RC (5.4.x)
-            url="https://downloads.php.net/stas/php-$SHORT_VERSION.tar.bz2"
-            wget -P "$bzipsdir" -O "$srcfile" "$url"
-        fi
-        if [ ! -s "$srcfile" -a -f "$srcfile" ]; then
-            rm "$srcfile"
-        fi
-
-        if [ ! -f "$srcfile" ]; then
-            echo "Fetching sources from stas's site failed"
-            echo $url
-            #use dsp's RC (5.5.x)
-            url="https://downloads.php.net/dsp/php-$SHORT_VERSION.tar.bz2"
-            wget -P "$bzipsdir" -O "$srcfile" "$url"
-        fi
-        if [ ! -s "$srcfile" -a -f "$srcfile" ]; then
-            rm "$srcfile"
-        fi
-
-        if [ ! -f "$srcfile" ]; then
-            echo "Fetching sources from dsp's site failed"
-            echo $url
-            #use Tyrael's RC (5.6.x)
-            url="https://downloads.php.net/tyrael/php-$SHORT_VERSION.tar.bz2"
+            url="http://docs.php.net/distributions/php-$SHORT_VERSION.tar.bz2"
             wget -P "$bzipsdir" -O "$srcfile" "$url"
         fi
         if [ ! -s "$srcfile" -a -f "$srcfile" ]; then


### PR DESCRIPTION
Museum.php.net is outdated (last updated in 2016, no PHP 7.1 etc.) and not any of fallback sites works.